### PR TITLE
Adding Send + Sync trait bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clamav-client"
 version = "2.0.0"
 edition = "2021"
-rust-version = "1.56.0"
+rust-version = "1.63.0"
 authors = ["Thorsten Blum <thorsten.blum@toblux.com>"]
 homepage = "https://github.com/toblux/rust-clamav-client"
 repository = "https://github.com/toblux/rust-clamav-client"
@@ -14,20 +14,23 @@ keywords = ["clamav", "clamd", "anitvirus", "async", "tokio"]
 exclude = ["clamd", ".github"]
 
 [dependencies]
-tokio = { version = "1.34.0", default-features = false, features = ["fs", "io-util", "net"], optional = true }
-tokio-stream = { version = "0.1.14", default-features = false, optional = true }
-async-std = { version = "1.12.0", optional = true }
 bytes = { version = "1", optional = true }
+async-net = {version = "2.0.0", optional = true}
+futures-lite = {version = "2.5.0", optional = true}
+async-fs = {version = "2.1.2", optional = true}
+blocking = {version = "1.6.1" }
 
 [dev-dependencies]
-tokio = { version = "1.34.0", features = ["io-std", "macros", "rt"] }
-tokio-util = { version = "0.7.10", features = ["io"] }
-async-std = { version = "1.12.0", features = ["attributes"] }
+async-std = { version = "1.13.0", features = ["attributes"] }
+tokio = { version = "1.42.0", features = ["full"] }
+tokio-util = { version = "0.7.13", features = ["io"] }
 
 [features]
-tokio = ["dep:tokio"]
-tokio-stream = ["tokio", "dep:tokio-stream", "dep:bytes"]
-async-std = ["dep:async-std", "dep:bytes"]
+async = ["dep:bytes", "dep:async-net", "dep:futures-lite", "dep:async-fs", ]
+tokio = ["async"]
+tokio-stream = ["async"]
+async-std = ["async"]
+
 
 [package.metadata.docs.rs]
 features = ["tokio", "tokio-stream", "async-std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ exclude = ["clamd", ".github"]
 tokio = { version = "1.34.0", default-features = false, features = ["fs", "io-util", "net"], optional = true }
 tokio-stream = { version = "0.1.14", default-features = false, optional = true }
 async-std = { version = "1.12.0", optional = true }
-async-trait = { version = "0.1.77", optional = true }
 bytes = { version = "1", optional = true }
 
 [dev-dependencies]
@@ -26,9 +25,9 @@ tokio-util = { version = "0.7.10", features = ["io"] }
 async-std = { version = "1.12.0", features = ["attributes"] }
 
 [features]
-tokio = ["dep:async-trait", "dep:tokio"]
+tokio = ["dep:tokio"]
 tokio-stream = ["tokio", "dep:tokio-stream", "dep:bytes"]
-async-std = ["dep:async-trait", "dep:async-std", "dep:bytes"]
+async-std = ["dep:async-std", "dep:bytes"]
 
 [package.metadata.docs.rs]
 features = ["tokio", "tokio-stream", "async-std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clamav-client"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.56.0"
 authors = ["Thorsten Blum <thorsten.blum@toblux.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clamav-client"
 version = "2.0.0"
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.72.1"
 authors = ["Thorsten Blum <thorsten.blum@toblux.com>"]
 homepage = "https://github.com/toblux/rust-clamav-client"
 repository = "https://github.com/toblux/rust-clamav-client"

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -1,141 +1,11 @@
-use async_std::{
-    fs::File,
-    io::{self, ReadExt, WriteExt},
-    net::{TcpStream, ToSocketAddrs},
-    path::Path,
-    stream::{Stream, StreamExt},
-};
+use std::path::Path;
 
-#[cfg(unix)]
-use async_std::os::unix::net::UnixStream;
+use async_fs::File;
+use futures_lite::Stream;
 
-use super::{IoResult, DEFAULT_CHUNK_SIZE, END_OF_STREAM, INSTREAM, PING, PONG, SHUTDOWN, VERSION};
-
-async fn send_command<RW: ReadExt + WriteExt + Unpin>(
-    mut stream: RW,
-    command: &[u8],
-    expected_response_length: Option<usize>,
-) -> IoResult {
-    stream.write_all(command).await?;
-    stream.flush().await?;
-
-    let mut response = match expected_response_length {
-        Some(len) => Vec::with_capacity(len),
-        None => Vec::new(),
-    };
-
-    stream.read_to_end(&mut response).await?;
-    Ok(response)
-}
-
-async fn scan<R: ReadExt + Unpin, RW: ReadExt + WriteExt + Unpin>(
-    mut input: R,
-    chunk_size: Option<usize>,
-    mut stream: RW,
-) -> IoResult {
-    stream.write_all(INSTREAM).await?;
-
-    let chunk_size = chunk_size
-        .unwrap_or(DEFAULT_CHUNK_SIZE)
-        .min(u32::MAX as usize);
-
-    let mut buffer = vec![0; chunk_size];
-
-    loop {
-        let len = input.read(&mut buffer[..]).await?;
-        if len != 0 {
-            stream.write_all(&(len as u32).to_be_bytes()).await?;
-            stream.write_all(&buffer[..len]).await?;
-        } else {
-            stream.write_all(END_OF_STREAM).await?;
-            stream.flush().await?;
-            break;
-        }
-    }
-
-    let mut response = Vec::new();
-    stream.read_to_end(&mut response).await?;
-    Ok(response)
-}
-
-async fn _scan_stream<
-    S: Stream<Item = Result<bytes::Bytes, std::io::Error>>,
-    RW: ReadExt + WriteExt + Unpin,
->(
-    input_stream: S,
-    chunk_size: Option<usize>,
-    mut output_stream: RW,
-) -> IoResult {
-    output_stream.write_all(INSTREAM).await?;
-
-    let chunk_size = chunk_size
-        .unwrap_or(DEFAULT_CHUNK_SIZE)
-        .min(u32::MAX as usize);
-
-    let mut input_stream = std::pin::pin!(input_stream);
-
-    while let Some(bytes) = input_stream.next().await {
-        let bytes = bytes?;
-        let bytes = bytes.as_ref();
-        for chunk in bytes.chunks(chunk_size) {
-            let len = chunk.len();
-            output_stream.write_all(&(len as u32).to_be_bytes()).await?;
-            output_stream.write_all(chunk).await?;
-        }
-    }
-
-    output_stream.write_all(END_OF_STREAM).await?;
-    output_stream.flush().await?;
-
-    let mut response = Vec::new();
-    output_stream.read_to_end(&mut response).await?;
-    Ok(response)
-}
-
-/// Use a TCP connection to communicate with a ClamAV server
-#[derive(Copy, Clone)]
-pub struct Tcp<A: ToSocketAddrs + Send + Sync> {
-    /// The address (host and port) of the ClamAV server
-    pub host_address: A,
-}
-
-/// Use a Unix socket connection to communicate with a ClamAV server
-#[derive(Copy, Clone)]
-#[cfg(unix)]
-pub struct Socket<P: AsRef<Path> + Send + Sync> {
-    /// The socket file path of the ClamAV server
-    pub socket_path: P,
-}
-
-/// The communication protocol to use
-pub trait TransportProtocol {
-    /// Bidirectional stream
-    type Stream: ReadExt + WriteExt + Unpin;
-
-    /// Converts the protocol instance into the corresponding stream
-    fn connect(&self) -> impl std::future::Future<Output = io::Result<Self::Stream>> + Send;
-}
-
-impl<A> TransportProtocol for Tcp<A>
-where
-    A: ToSocketAddrs + Send + Sync,
-    <A as async_std::net::ToSocketAddrs>::Iter: std::marker::Send,
-{
-    type Stream = TcpStream;
-
-    fn connect(&self) -> impl std::future::Future<Output = io::Result<Self::Stream>> + Send {
-        TcpStream::connect(&self.host_address)
-    }
-}
-
-#[cfg(unix)]
-impl<P: AsRef<Path> + Send + Sync> TransportProtocol for Socket<P> {
-    type Stream = UnixStream;
-
-    fn connect(&self) -> impl std::future::Future<Output = io::Result<Self::Stream>> + Send {
-        UnixStream::connect(&self.socket_path)
-    }
-}
+use super::{IoResult, PING, SHUTDOWN, VERSION};
+pub use crate::nonblocking::{scan, send_command, TransportProtocol};
+pub use crate::{Socket, Tcp};
 
 /// Sends a ping request to ClamAV
 ///
@@ -166,7 +36,7 @@ impl<P: AsRef<Path> + Send + Sync> TransportProtocol for Socket<P> {
 ///
 pub async fn ping<T: TransportProtocol>(connection: T) -> IoResult {
     let stream = connection.connect().await?;
-    send_command(stream, PING, Some(PONG.len())).await
+    send_command(stream, PING).await
 }
 
 /// Gets the version number from ClamAV
@@ -196,7 +66,7 @@ pub async fn ping<T: TransportProtocol>(connection: T) -> IoResult {
 ///
 pub async fn get_version<T: TransportProtocol>(connection: T) -> IoResult {
     let stream = connection.connect().await?;
-    send_command(stream, VERSION, None).await
+    send_command(stream, VERSION).await
 }
 
 /// Scans a file for viruses
@@ -262,7 +132,7 @@ pub async fn scan_buffer<T: TransportProtocol>(
 /// An [`IoResult`] containing the server's response as a vector of bytes
 ///
 pub async fn scan_stream<
-    S: Stream<Item = Result<bytes::Bytes, io::Error>>,
+    S: Stream<Item = Result<bytes::Bytes, std::io::Error>>,
     T: TransportProtocol,
 >(
     input_stream: S,
@@ -270,7 +140,7 @@ pub async fn scan_stream<
     chunk_size: Option<usize>,
 ) -> IoResult {
     let output_stream = connection.connect().await?;
-    _scan_stream(input_stream, chunk_size, output_stream).await
+    crate::nonblocking::scan_stream(input_stream, chunk_size, output_stream).await
 }
 
 /// Shuts down a ClamAV server
@@ -289,5 +159,5 @@ pub async fn scan_stream<
 ///
 pub async fn shutdown<T: TransportProtocol>(connection: T) -> IoResult {
     let stream = connection.connect().await?;
-    send_command(stream, SHUTDOWN, None).await
+    send_command(stream, SHUTDOWN).await
 }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,0 +1,209 @@
+use std::{
+    fs::File,
+    io::{Read, Write},
+    net::TcpStream,
+    path::Path,
+};
+
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+
+use crate::{
+    IoResult, Socket, Tcp, DEFAULT_CHUNK_SIZE, END_OF_STREAM, INSTREAM, PING, PONG, SHUTDOWN,
+    VERSION,
+};
+
+fn send_command<RW: Read + Write>(
+    mut stream: RW,
+    command: &[u8],
+    expected_response_length: Option<usize>,
+) -> IoResult {
+    stream.write_all(command)?;
+    stream.flush()?;
+
+    let mut response = match expected_response_length {
+        Some(len) => Vec::with_capacity(len),
+        None => Vec::new(),
+    };
+
+    stream.read_to_end(&mut response)?;
+    Ok(response)
+}
+
+fn scan<R: Read, RW: Read + Write>(
+    mut input: R,
+    chunk_size: Option<usize>,
+    mut stream: RW,
+) -> IoResult {
+    stream.write_all(INSTREAM)?;
+
+    let chunk_size = chunk_size
+        .unwrap_or(DEFAULT_CHUNK_SIZE)
+        .min(u32::MAX as usize);
+    let mut buffer = vec![0; chunk_size];
+    loop {
+        let len = input.read(&mut buffer[..])?;
+        if len != 0 {
+            stream.write_all(&(len as u32).to_be_bytes())?;
+            stream.write_all(&buffer[..len])?;
+        } else {
+            stream.write_all(END_OF_STREAM)?;
+            stream.flush()?;
+            break;
+        }
+    }
+
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response)?;
+    Ok(response)
+}
+
+/// The communication protocol to use
+pub trait TransportProtocol {
+    /// Bidirectional stream
+    type Stream: Read + Write;
+
+    /// Converts the protocol instance into the corresponding stream
+    fn connect(&self) -> std::io::Result<Self::Stream>;
+}
+
+impl<A: std::net::ToSocketAddrs> TransportProtocol for Tcp<A> {
+    type Stream = TcpStream;
+
+    fn connect(&self) -> std::io::Result<Self::Stream> {
+        TcpStream::connect(&self.host_address)
+    }
+}
+
+#[cfg(unix)]
+impl<P: AsRef<Path>> TransportProtocol for Socket<P> {
+    type Stream = UnixStream;
+
+    fn connect(&self) -> std::io::Result<Self::Stream> {
+        UnixStream::connect(&self.socket_path)
+    }
+}
+
+/// Sends a ping request to ClamAV
+///
+/// This function establishes a connection to a ClamAV server and sends the PING
+/// command to it. If the server is available, it responds with [`PONG`].
+///
+/// # Arguments
+///
+/// * `connection`: The connection type to use - either TCP or a Unix socket connection
+///
+/// # Returns
+///
+/// An [`IoResult`] containing the server's response as a vector of bytes
+///
+/// # Example
+///
+/// ```
+/// let clamd_tcp = clamav_client::Tcp{ host_address: "localhost:3310" };
+/// let clamd_available = match clamav_client::ping(clamd_tcp) {
+///     Ok(ping_response) => ping_response == clamav_client::PONG,
+///     Err(_) => false,
+/// };
+/// # assert!(clamd_available);
+/// ```
+///
+pub fn ping<T: TransportProtocol>(connection: T) -> IoResult {
+    let stream = connection.connect()?;
+    send_command(stream, PING, Some(PONG.len()))
+}
+
+/// Gets the version number from ClamAV
+///
+/// This function establishes a connection to a ClamAV server and sends the
+/// VERSION command to it. If the server is available, it responds with its
+/// version number.
+///
+/// # Arguments
+///
+/// * `connection`: The connection type to use - either TCP or a Unix socket connection
+///
+/// # Returns
+///
+/// An [`IoResult`] containing the server's response as a vector of bytes
+///
+/// # Example
+///
+/// ```
+/// let clamd_tcp = clamav_client::Tcp{ host_address: "localhost:3310" };
+/// let version = clamav_client::get_version(clamd_tcp).unwrap();
+/// # assert!(version.starts_with(b"ClamAV"));
+/// ```
+///
+pub fn get_version<T: TransportProtocol>(connection: T) -> IoResult {
+    let stream = connection.connect()?;
+    send_command(stream, VERSION, None)
+}
+
+/// Scans a file for viruses
+///
+/// This function reads data from a file located at the specified `file_path`
+/// and streams it to a ClamAV server for scanning.
+///
+/// # Arguments
+///
+/// * `file_path`: The path to the file to be scanned
+/// * `connection`: The connection type to use - either TCP or a Unix socket connection
+/// * `chunk_size`: An optional chunk size for reading data. If [`None`], a default chunk size is used
+///
+/// # Returns
+///
+/// An [`IoResult`] containing the server's response as a vector of bytes
+///
+pub fn scan_file<P: AsRef<Path>, T: TransportProtocol>(
+    file_path: P,
+    connection: T,
+    chunk_size: Option<usize>,
+) -> IoResult {
+    let file = File::open(file_path)?;
+    let stream = connection.connect()?;
+    scan(file, chunk_size, stream)
+}
+
+/// Scans a data buffer for viruses
+///
+/// This function streams the provided `buffer` data to a ClamAV server for
+/// scanning.
+///
+/// # Arguments
+///
+/// * `buffer`: The data to be scanned
+/// * `connection`: The connection type to use - either TCP or a Unix socket connection
+/// * `chunk_size`: An optional chunk size for reading data. If [`None`], a default chunk size is used
+///
+/// # Returns
+///
+/// An [`IoResult`] containing the server's response as a vector of bytes
+///
+pub fn scan_buffer<T: TransportProtocol>(
+    buffer: &[u8],
+    connection: T,
+    chunk_size: Option<usize>,
+) -> IoResult {
+    let stream = connection.connect()?;
+    scan(buffer, chunk_size, stream)
+}
+
+/// Shuts down a ClamAV server
+///
+/// This function establishes a connection to a ClamAV server and sends the
+/// SHUTDOWN command to it. If the server is available, it will perform a clean
+/// exit and shut itself down. The response will be empty.
+///
+/// # Arguments
+///
+/// * `connection`: The connection type to use - either TCP or a Unix socket connection
+///
+/// # Returns
+///
+/// An [`IoResult`] containing the server's response
+///
+pub fn shutdown<T: TransportProtocol>(connection: T) -> IoResult {
+    let stream = connection.connect()?;
+    send_command(stream, SHUTDOWN, None)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,11 @@ pub mod tokio;
 /// Use the feature flag "async-std" to enable this module
 pub mod async_std;
 
-/// Blocking
+/// Interacting with ClamAV in a synchronous (blocking) way
 pub mod blocking;
 
-/// Nonblocking
+#[cfg(feature = "async")]
+/// Interacting with ClamAV in a asynchronous (non-blocking) way
 pub mod nonblocking;
 
 /// Custom result type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 
-use std::path::Path;
+use std::{net::ToSocketAddrs, path::Path};
 
 #[cfg(feature = "tokio")]
 /// Use the feature flag "tokio" or "tokio-stream" to enable this module
@@ -40,7 +40,7 @@ pub use blocking::{get_version, ping, scan_buffer, scan_file};
 
 /// Use a TCP connection to communicate with a ClamAV server
 #[derive(Debug, Clone, Copy)]
-pub struct Tcp<T> {
+pub struct Tcp<T: ToSocketAddrs> {
     /// The address (host and port) of the ClamAV server
     pub host_address: T,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 
+use std::path::Path;
+
 #[cfg(feature = "tokio")]
 /// Use the feature flag "tokio" or "tokio-stream" to enable this module
 pub mod tokio;
@@ -9,22 +11,17 @@ pub mod tokio;
 /// Use the feature flag "async-std" to enable this module
 pub mod async_std;
 
-use std::{
-    fs::File,
-    io::{self, Error, Read, Write},
-    net::{TcpStream, ToSocketAddrs},
-    path::Path,
-    str::{self, Utf8Error},
-};
+/// Blocking
+pub mod blocking;
 
-#[cfg(unix)]
-use std::os::unix::net::UnixStream;
+/// Nonblocking
+pub mod nonblocking;
 
 /// Custom result type
-pub type IoResult = Result<Vec<u8>, Error>;
+pub type IoResult = Result<Vec<u8>, std::io::Error>;
 
 /// Custom result type
-pub type Utf8Result = Result<bool, Utf8Error>;
+pub type Utf8Result = Result<bool, std::str::Utf8Error>;
 
 /// Default chunk size in bytes for reading data during scanning
 const DEFAULT_CHUNK_SIZE: usize = 4096;
@@ -39,57 +36,21 @@ const END_OF_STREAM: &[u8; 4] = &[0, 0, 0, 0];
 /// ClamAV's response to a PING request
 pub const PONG: &[u8; 5] = b"PONG\0";
 
-fn send_command<RW: Read + Write>(
-    mut stream: RW,
-    command: &[u8],
-    expected_response_length: Option<usize>,
-) -> IoResult {
-    stream.write_all(command)?;
-    stream.flush()?;
+pub use blocking::{get_version, ping, scan_buffer, scan_file};
 
-    let mut response = match expected_response_length {
-        Some(len) => Vec::with_capacity(len),
-        None => Vec::new(),
-    };
-
-    stream.read_to_end(&mut response)?;
-    Ok(response)
+/// Use a TCP connection to communicate with a ClamAV server
+#[derive(Debug, Clone, Copy)]
+pub struct Tcp<T> {
+    /// The address (host and port) of the ClamAV server
+    pub host_address: T,
 }
 
-fn _ping<RW: Read + Write>(stream: RW) -> IoResult {
-    send_command(stream, PING, Some(PONG.len()))
-}
-
-fn _get_version<RW: Read + Write>(stream: RW) -> IoResult {
-    send_command(stream, VERSION, None)
-}
-
-fn scan<R: Read, RW: Read + Write>(
-    mut input: R,
-    chunk_size: Option<usize>,
-    mut stream: RW,
-) -> IoResult {
-    stream.write_all(INSTREAM)?;
-
-    let chunk_size = chunk_size
-        .unwrap_or(DEFAULT_CHUNK_SIZE)
-        .min(u32::MAX as usize);
-    let mut buffer = vec![0; chunk_size];
-    loop {
-        let len = input.read(&mut buffer[..])?;
-        if len != 0 {
-            stream.write_all(&(len as u32).to_be_bytes())?;
-            stream.write_all(&buffer[..len])?;
-        } else {
-            stream.write_all(END_OF_STREAM)?;
-            stream.flush()?;
-            break;
-        }
-    }
-
-    let mut response = Vec::new();
-    stream.read_to_end(&mut response)?;
-    Ok(response)
+/// Use a Unix socket connection to communicate with a ClamAV server
+#[derive(Debug, Clone, Copy)]
+#[cfg(unix)]
+pub struct Socket<P: AsRef<Path>> {
+    /// The socket file path of the ClamAV server
+    pub socket_path: P,
 }
 
 /// Checks whether the ClamAV response indicates that the scanned content is
@@ -109,171 +70,6 @@ fn scan<R: Read, RW: Read + Write>(
 /// An [`Utf8Result`] containing the scan result as [`bool`]
 ///
 pub fn clean(response: &[u8]) -> Utf8Result {
-    let response = str::from_utf8(response)?;
+    let response = std::str::from_utf8(response)?;
     Ok(response.contains("OK") && !response.contains("FOUND"))
-}
-
-/// Use a TCP connection to communicate with a ClamAV server
-#[derive(Copy, Clone)]
-pub struct Tcp<A: ToSocketAddrs> {
-    /// The address (host and port) of the ClamAV server
-    pub host_address: A,
-}
-
-/// Use a Unix socket connection to communicate with a ClamAV server
-#[derive(Copy, Clone)]
-#[cfg(unix)]
-pub struct Socket<P: AsRef<Path>> {
-    /// The socket file path of the ClamAV server
-    pub socket_path: P,
-}
-
-/// The communication protocol to use
-pub trait TransportProtocol {
-    /// Bidirectional stream
-    type Stream: Read + Write;
-
-    /// Converts the protocol instance into the corresponding stream
-    fn connect(&self) -> io::Result<Self::Stream>;
-}
-
-impl<A: ToSocketAddrs> TransportProtocol for Tcp<A> {
-    type Stream = TcpStream;
-
-    fn connect(&self) -> io::Result<Self::Stream> {
-        TcpStream::connect(&self.host_address)
-    }
-}
-
-#[cfg(unix)]
-impl<P: AsRef<Path>> TransportProtocol for Socket<P> {
-    type Stream = UnixStream;
-
-    fn connect(&self) -> io::Result<Self::Stream> {
-        UnixStream::connect(&self.socket_path)
-    }
-}
-
-/// Sends a ping request to ClamAV
-///
-/// This function establishes a connection to a ClamAV server and sends the PING
-/// command to it. If the server is available, it responds with [`PONG`].
-///
-/// # Arguments
-///
-/// * `connection`: The connection type to use - either TCP or a Unix socket connection
-///
-/// # Returns
-///
-/// An [`IoResult`] containing the server's response as a vector of bytes
-///
-/// # Example
-///
-/// ```
-/// let clamd_tcp = clamav_client::Tcp{ host_address: "localhost:3310" };
-/// let clamd_available = match clamav_client::ping(clamd_tcp) {
-///     Ok(ping_response) => ping_response == clamav_client::PONG,
-///     Err(_) => false,
-/// };
-/// # assert!(clamd_available);
-/// ```
-///
-pub fn ping<T: TransportProtocol>(connection: T) -> IoResult {
-    let stream = connection.connect()?;
-    _ping(stream)
-}
-
-/// Gets the version number from ClamAV
-///
-/// This function establishes a connection to a ClamAV server and sends the
-/// VERSION command to it. If the server is available, it responds with its
-/// version number.
-///
-/// # Arguments
-///
-/// * `connection`: The connection type to use - either TCP or a Unix socket connection
-///
-/// # Returns
-///
-/// An [`IoResult`] containing the server's response as a vector of bytes
-///
-/// # Example
-///
-/// ```
-/// let clamd_tcp = clamav_client::Tcp{ host_address: "localhost:3310" };
-/// let version = clamav_client::get_version(clamd_tcp).unwrap();
-/// # assert!(version.starts_with(b"ClamAV"));
-/// ```
-///
-pub fn get_version<T: TransportProtocol>(connection: T) -> IoResult {
-    let stream = connection.connect()?;
-    _get_version(stream)
-}
-
-/// Scans a file for viruses
-///
-/// This function reads data from a file located at the specified `file_path`
-/// and streams it to a ClamAV server for scanning.
-///
-/// # Arguments
-///
-/// * `file_path`: The path to the file to be scanned
-/// * `connection`: The connection type to use - either TCP or a Unix socket connection
-/// * `chunk_size`: An optional chunk size for reading data. If [`None`], a default chunk size is used
-///
-/// # Returns
-///
-/// An [`IoResult`] containing the server's response as a vector of bytes
-///
-pub fn scan_file<P: AsRef<Path>, T: TransportProtocol>(
-    file_path: P,
-    connection: T,
-    chunk_size: Option<usize>,
-) -> IoResult {
-    let file = File::open(file_path)?;
-    let stream = connection.connect()?;
-    scan(file, chunk_size, stream)
-}
-
-/// Scans a data buffer for viruses
-///
-/// This function streams the provided `buffer` data to a ClamAV server for
-/// scanning.
-///
-/// # Arguments
-///
-/// * `buffer`: The data to be scanned
-/// * `connection`: The connection type to use - either TCP or a Unix socket connection
-/// * `chunk_size`: An optional chunk size for reading data. If [`None`], a default chunk size is used
-///
-/// # Returns
-///
-/// An [`IoResult`] containing the server's response as a vector of bytes
-///
-pub fn scan_buffer<T: TransportProtocol>(
-    buffer: &[u8],
-    connection: T,
-    chunk_size: Option<usize>,
-) -> IoResult {
-    let stream = connection.connect()?;
-    scan(buffer, chunk_size, stream)
-}
-
-/// Shuts down a ClamAV server
-///
-/// This function establishes a connection to a ClamAV server and sends the
-/// SHUTDOWN command to it. If the server is available, it will perform a clean
-/// exit and shut itself down. The response will be empty.
-///
-/// # Arguments
-///
-/// * `connection`: The connection type to use - either TCP or a Unix socket connection
-///
-/// # Returns
-///
-/// An [`IoResult`] containing the server's response
-///
-pub fn shutdown<T: TransportProtocol>(connection: T) -> IoResult {
-    let stream = connection.connect()?;
-    send_command(stream, SHUTDOWN, None)
 }

--- a/src/nonblocking.rs
+++ b/src/nonblocking.rs
@@ -1,0 +1,137 @@
+use std::{
+    net::{SocketAddr, ToSocketAddrs},
+    path::Path,
+};
+
+use async_net::TcpStream;
+use futures_lite::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, Stream, StreamExt};
+
+#[cfg(unix)]
+use async_net::unix::UnixStream;
+
+use crate::{Socket, Tcp};
+
+use super::{IoResult, DEFAULT_CHUNK_SIZE, END_OF_STREAM, INSTREAM};
+
+/// The communication protocol to use
+pub trait TransportProtocol {
+    /// Bidirectional stream
+    type Stream: AsyncRead + AsyncWrite + Unpin;
+
+    /// Converts the protocol instance into the corresponding stream
+    fn connect(&self) -> impl std::future::Future<Output = std::io::Result<Self::Stream>> + Send;
+}
+
+impl<A> TransportProtocol for Tcp<A>
+where
+    A: ToSocketAddrs + Send + Sync + Clone + 'static,
+    <A as ToSocketAddrs>::Iter: Send,
+{
+    type Stream = TcpStream;
+
+    fn connect(&self) -> impl std::future::Future<Output = std::io::Result<Self::Stream>> + Send {
+        async {
+            let addrs = self.host_address.clone();
+            // It is not possible to set a `Send` trait bound on the iterator of async_net::AsyncToSocketAddrs::to_socket_addrs()
+            // However `ToSocketAddress::to_socket_addrs` might block
+            // Until we can set the trait bound on `AsyncToSocketAddrs` we have to use `blocking`
+            // to inform the async runtime that the task might block
+            match blocking::unblock(move || addrs.to_socket_addrs()).await {
+                Ok(it) => {
+                    let addr: Vec<SocketAddr> = it.collect();
+                    TcpStream::connect(addr.as_slice()).await
+                }
+                Err(err) => Err(err),
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+impl<P: AsRef<Path> + Send + Sync> TransportProtocol for Socket<P> {
+    type Stream = UnixStream;
+
+    fn connect(&self) -> impl std::future::Future<Output = std::io::Result<Self::Stream>> + Send {
+        UnixStream::connect(&self.socket_path)
+    }
+}
+
+/// Sends a command to ClamAV
+pub async fn send_command<RW: AsyncRead + AsyncWrite + Unpin>(
+    mut stream: RW,
+    command: &[u8],
+) -> IoResult {
+    stream.write_all(command).await?;
+    // stream.flush().await?;
+
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).await?;
+    Ok(response)
+}
+
+/// Scan async readable data with ClamAV
+pub async fn scan<R: AsyncRead + Unpin, RW: AsyncRead + AsyncWrite + Unpin>(
+    mut input: R,
+    chunk_size: Option<usize>,
+    mut stream: RW,
+) -> IoResult {
+    stream.write_all(INSTREAM).await?;
+
+    let chunk_size = chunk_size
+        .unwrap_or(DEFAULT_CHUNK_SIZE)
+        .min(u32::MAX as usize);
+
+    let mut buffer = vec![0; chunk_size];
+
+    loop {
+        let len = input.read(&mut buffer[..]).await?;
+        if len != 0 {
+            stream.write_all(&(len as u32).to_be_bytes()).await?;
+            stream.write_all(&buffer[..len]).await?;
+        } else {
+            stream.write_all(END_OF_STREAM).await?;
+            stream.flush().await?;
+            break;
+        }
+    }
+
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).await?;
+    Ok(response)
+}
+
+/// Scans a stream of data with ClamAV
+pub async fn scan_stream<S, RW>(
+    input_stream: S,
+    chunk_size: Option<usize>,
+    mut output_stream: RW,
+) -> IoResult
+where
+    S: Stream<Item = Result<bytes::Bytes, std::io::Error>>,
+    RW: AsyncRead + AsyncWrite + Unpin,
+{
+    output_stream.write_all(INSTREAM).await?;
+
+    let chunk_size = chunk_size
+        .unwrap_or(DEFAULT_CHUNK_SIZE)
+        .min(u32::MAX as usize);
+
+    let mut input_stream = std::pin::pin!(input_stream);
+
+    while let Some(bytes) = input_stream.next().await {
+        let bytes = bytes?;
+        let bytes = bytes.as_ref();
+        for chunk in bytes.chunks(chunk_size) {
+            let len = chunk.len();
+            output_stream.write_all(&(len as u32).to_be_bytes()).await?;
+            output_stream.write_all(chunk).await?;
+        }
+    }
+
+    output_stream.write_all(END_OF_STREAM).await?;
+    output_stream.flush().await?;
+
+    let mut response = Vec::new();
+    output_stream.read_to_end(&mut response).await?;
+    Ok(response)
+}

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,140 +1,12 @@
 use std::path::Path;
-use tokio::{
-    fs::File,
-    io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
-    net::{TcpStream, ToSocketAddrs},
-};
 
-#[cfg(unix)]
-use tokio::net::UnixStream;
+use async_fs::File;
 
-#[cfg(feature = "tokio-stream")]
-use tokio_stream::{Stream, StreamExt};
+pub use crate::nonblocking::{scan, send_command, TransportProtocol};
+pub use crate::{Socket, Tcp};
+use futures_lite::Stream;
 
-use super::{IoResult, DEFAULT_CHUNK_SIZE, END_OF_STREAM, INSTREAM, PING, PONG, SHUTDOWN, VERSION};
-
-async fn send_command<RW: AsyncRead + AsyncWrite + Unpin>(
-    mut stream: RW,
-    command: &[u8],
-    expected_response_length: Option<usize>,
-) -> IoResult {
-    stream.write_all(command).await?;
-    stream.flush().await?;
-
-    let mut response = match expected_response_length {
-        Some(len) => Vec::with_capacity(len),
-        None => Vec::new(),
-    };
-
-    stream.read_to_end(&mut response).await?;
-    Ok(response)
-}
-
-async fn scan<R: AsyncRead + Unpin, RW: AsyncRead + AsyncWrite + Unpin>(
-    mut input: R,
-    chunk_size: Option<usize>,
-    mut stream: RW,
-) -> IoResult {
-    stream.write_all(INSTREAM).await?;
-
-    let chunk_size = chunk_size
-        .unwrap_or(DEFAULT_CHUNK_SIZE)
-        .min(u32::MAX as usize);
-
-    let mut buffer = vec![0; chunk_size];
-
-    loop {
-        let len = input.read(&mut buffer[..]).await?;
-        if len != 0 {
-            stream.write_all(&(len as u32).to_be_bytes()).await?;
-            stream.write_all(&buffer[..len]).await?;
-        } else {
-            stream.write_all(END_OF_STREAM).await?;
-            stream.flush().await?;
-            break;
-        }
-    }
-
-    let mut response = Vec::new();
-    stream.read_to_end(&mut response).await?;
-    Ok(response)
-}
-
-#[cfg(feature = "tokio-stream")]
-async fn _scan_stream<
-    S: Stream<Item = Result<bytes::Bytes, std::io::Error>>,
-    RW: AsyncRead + AsyncWrite + Unpin,
->(
-    input_stream: S,
-    chunk_size: Option<usize>,
-    mut output_stream: RW,
-) -> IoResult {
-    output_stream.write_all(INSTREAM).await?;
-
-    let chunk_size = chunk_size
-        .unwrap_or(DEFAULT_CHUNK_SIZE)
-        .min(u32::MAX as usize);
-
-    let mut input_stream = std::pin::pin!(input_stream);
-
-    while let Some(bytes) = input_stream.next().await {
-        let bytes = bytes?;
-        let bytes = bytes.as_ref();
-        for chunk in bytes.chunks(chunk_size) {
-            let len = chunk.len();
-            output_stream.write_all(&(len as u32).to_be_bytes()).await?;
-            output_stream.write_all(chunk).await?;
-        }
-    }
-
-    output_stream.write_all(END_OF_STREAM).await?;
-    output_stream.flush().await?;
-
-    let mut response = Vec::new();
-    output_stream.read_to_end(&mut response).await?;
-    Ok(response)
-}
-
-/// Use a TCP connection to communicate with a ClamAV server
-#[derive(Copy, Clone)]
-pub struct Tcp<A: ToSocketAddrs + Send + Sync> {
-    /// The address (host and port) of the ClamAV server
-    pub host_address: A,
-}
-
-/// Use a Unix socket connection to communicate with a ClamAV server
-#[derive(Copy, Clone)]
-#[cfg(unix)]
-pub struct Socket<P: AsRef<Path> + Send + Sync> {
-    /// The socket file path of the ClamAV server
-    pub socket_path: P,
-}
-
-/// The communication protocol to use
-pub trait TransportProtocol {
-    /// Bidirectional stream
-    type Stream: AsyncRead + AsyncWrite + Unpin;
-
-    /// Converts the protocol instance into the corresponding stream
-    fn connect(&self) -> impl std::future::Future<Output = io::Result<Self::Stream>> + Send;
-}
-
-impl<A: ToSocketAddrs + Send + Sync> TransportProtocol for Tcp<A> {
-    type Stream = TcpStream;
-
-    fn connect(&self) -> impl std::future::Future<Output = io::Result<Self::Stream>> + Send {
-        TcpStream::connect(&self.host_address)
-    }
-}
-
-#[cfg(unix)]
-impl<P: AsRef<Path> + Send + Sync> TransportProtocol for Socket<P> {
-    type Stream = UnixStream;
-
-    fn connect(&self) -> impl std::future::Future<Output = io::Result<Self::Stream>> + Send {
-        UnixStream::connect(&self.socket_path)
-    }
-}
+use super::{IoResult, PING, SHUTDOWN, VERSION};
 
 /// Sends a ping request to ClamAV
 ///
@@ -165,7 +37,7 @@ impl<P: AsRef<Path> + Send + Sync> TransportProtocol for Socket<P> {
 ///
 pub async fn ping<T: TransportProtocol>(connection: T) -> IoResult {
     let stream = connection.connect().await?;
-    send_command(stream, PING, Some(PONG.len())).await
+    send_command(stream, PING).await
 }
 
 /// Gets the version number from ClamAV
@@ -195,7 +67,7 @@ pub async fn ping<T: TransportProtocol>(connection: T) -> IoResult {
 ///
 pub async fn get_version<T: TransportProtocol>(connection: T) -> IoResult {
     let stream = connection.connect().await?;
-    send_command(stream, VERSION, None).await
+    send_command(stream, VERSION).await
 }
 
 /// Scans a file for viruses
@@ -262,7 +134,7 @@ pub async fn scan_buffer<T: TransportProtocol>(
 ///
 #[cfg(feature = "tokio-stream")]
 pub async fn scan_stream<
-    S: Stream<Item = Result<bytes::Bytes, io::Error>>,
+    S: Stream<Item = Result<bytes::Bytes, std::io::Error>>,
     T: TransportProtocol,
 >(
     input_stream: S,
@@ -270,7 +142,7 @@ pub async fn scan_stream<
     chunk_size: Option<usize>,
 ) -> IoResult {
     let output_stream = connection.connect().await?;
-    _scan_stream(input_stream, chunk_size, output_stream).await
+    crate::nonblocking::scan_stream(input_stream, chunk_size, output_stream).await
 }
 
 /// Shuts down a ClamAV server
@@ -289,5 +161,5 @@ pub async fn scan_stream<
 ///
 pub async fn shutdown<T: TransportProtocol>(connection: T) -> IoResult {
     let stream = connection.connect().await?;
-    send_command(stream, SHUTDOWN, None).await
+    send_command(stream, SHUTDOWN).await
 }

--- a/tests/clamav_client.rs
+++ b/tests/clamav_client.rs
@@ -758,3 +758,24 @@ mod async_std_stream_tests {
 
 #[cfg(feature = "async-std")]
 mod async_std_util;
+
+// Checks if the library can be used with work stealing async runtimes like tokio
+mod test_future_is_send {
+    fn is_send<T: Send>(_t: T) {}
+
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
+    async fn test_tokio_future_is_send() {
+        use clamav_client::tokio::{scan_buffer, Socket, Tcp};
+        is_send(scan_buffer(&[], Tcp { host_address: "" }, None));
+        is_send(scan_buffer(&[], Socket { socket_path: "" }, None));
+    }
+
+    #[cfg(feature = "async-std")]
+    #[async_std::test]
+    async fn test_async_std_future_is_send() {
+        use clamav_client::async_std::{scan_buffer, Socket, Tcp};
+        is_send(scan_buffer(&[], Tcp { host_address: "" }, None));
+        is_send(scan_buffer(&[], Socket { socket_path: "" }, None));
+    }
+}

--- a/tests/clamav_client.rs
+++ b/tests/clamav_client.rs
@@ -766,16 +766,23 @@ mod test_future_is_send {
     #[cfg(feature = "tokio")]
     #[tokio::test]
     async fn test_tokio_future_is_send() {
-        use clamav_client::tokio::{scan_buffer, Socket, Tcp};
+        use clamav_client::tokio::{self, scan_buffer, Tcp};
         is_send(scan_buffer(&[], Tcp { host_address: "" }, None));
-        is_send(scan_buffer(&[], Socket { socket_path: "" }, None));
+
+        #[cfg(unix)]
+        is_send(scan_buffer(&[], tokio::Socket { socket_path: "" }, None));
     }
 
     #[cfg(feature = "async-std")]
     #[async_std::test]
     async fn test_async_std_future_is_send() {
-        use clamav_client::async_std::{scan_buffer, Socket, Tcp};
+        use clamav_client::async_std::{self, scan_buffer, Tcp};
         is_send(scan_buffer(&[], Tcp { host_address: "" }, None));
-        is_send(scan_buffer(&[], Socket { socket_path: "" }, None));
+        #[cfg(unix)]
+        is_send(scan_buffer(
+            &[],
+            async_std::Socket { socket_path: "" },
+            None,
+        ));
     }
 }


### PR DESCRIPTION
Futures that are missing the Send and Sync trait bounds are inconvenient when using a work stealing runtime like tokio.

The following code doesn't compile:
```rust
use std::net::SocketAddr;

use clamav_client::tokio::{scan_buffer, Tcp};

#[tokio::main]
async fn main() {
    let tcp = Tcp {
        host_address: "127.0.0.1:3310".parse::<SocketAddr>().unwrap(),
    };
    tokio::spawn(async move { scan_buffer(&[1, 2, 3], tcp, None).await });
}
```

<details>
  <summary>compiler error</summary>
  
```bash
error[E0277]: `dyn Future<Output = Result<tokio::net::TcpStream, std::io::Error>>` cannot be sent between threads safely
    --> src/bin/tokio.rs:10:5
     |
10   |     tokio::spawn(async move { scan_buffer(&[1, 2, 3], tcp, None).await });
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Future<Output = Result<tokio::net::TcpStream, std::io::Error>>` cannot be sent between threads safely
     |
     = help: the trait `Send` is not implemented for `dyn Future<Output = Result<tokio::net::TcpStream, std::io::Error>>`
     = note: required for `Unique<dyn Future<Output = Result<tokio::net::TcpStream, std::io::Error>>>` to implement `Send`
note: required because it appears within the type `Box<dyn Future<Output = Result<tokio::net::TcpStream, std::io::Error>>>`
    --> /Users/raui/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:231:12
     |
231  | pub struct Box<
     |            ^^^
note: required because it appears within the type `Pin<Box<dyn Future<Output = Result<tokio::net::TcpStream, std::io::Error>>>>`
    --> /Users/raui/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/pin.rs:1089:12
     |
1089 | pub struct Pin<Ptr> {
     |            ^^^
note: required because it's used within this `async` fn body
    --> /Users/raui/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clamav-client-1.0.0/src/tokio.rs:248:15
     |
248  |   ) -> IoResult {
     |  _______________^
249  | |     let stream = connection.connect().await?;
250  | |     scan(buffer, chunk_size, stream).await
251  | | }
     | |_^
note: required because it's used within this `async` block
    --> src/bin/tokio.rs:10:18
     |
10   |     tokio::spawn(async move { scan_buffer(&[1, 2, 3], tcp, None).await });
     |                  ^^^^^^^^^^
note: required by a bound in `tokio::spawn`
    --> /Users/raui/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.42.0/src/task/spawn.rs:168:21
     |
166  |     pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
     |            ----- required by a bound in this function
167  |     where
168  |         F: Future + Send + 'static,
     |                     ^^^^ required by this bound in `spawn`
     = note: the full name for the type has been written to '/Users/raui/dev/rs/clamav2/target/debug/deps/tokio-88257f09712d00a7.long-type-314989814868166026.txt'
     = note: consider using `--verbose` to print the full type name to the console

For more information about this error, try `rustc --explain E0277`.
error: could not compile `clamav2` (bin "tokio") due to 1 previous error
```
  
</details>

This PR adds the corresponding trait bounds, removes the `async-trait` and upps the version number to `2.0.0` according to semver.