### PR TITLE
Remove async-trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clamav-client"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.63.0"
 authors = ["Thorsten Blum <thorsten.blum@toblux.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ exclude = ["clamd", ".github"]
 tokio = { version = "1.34.0", default-features = false, features = ["fs", "io-util", "net"], optional = true }
 tokio-stream = { version = "0.1.14", default-features = false, optional = true }
 async-std = { version = "1.12.0", optional = true }
-async-trait = { version = "0.1.77", optional = true }
 bytes = { version = "1", optional = true }
 
 [dev-dependencies]
@@ -26,9 +25,9 @@ tokio-util = { version = "0.7.10", features = ["io"] }
 async-std = { version = "1.12.0", features = ["attributes"] }
 
 [features]
-tokio = ["dep:async-trait", "dep:tokio"]
+tokio = ["dep:tokio"]
 tokio-stream = ["tokio", "dep:tokio-stream", "dep:bytes"]
-async-std = ["dep:async-trait", "dep:async-std", "dep:bytes"]
+async-std = ["dep:async-std", "dep:bytes"]
 
 [package.metadata.docs.rs]
 features = ["tokio", "tokio-stream", "async-std"]

--- a/README.md
+++ b/README.md
@@ -228,3 +228,4 @@ Contributions are welcome!
 - [Paul Makles](https://github.com/insertish)
 - [Sean Clarke](https://github.com/SeanEClarke)
 - [Kanji Tanaka](https://github.com/kaicoh)
+- [Raui Ghazaleh](https://github.com/raui100)

--- a/README.md
+++ b/README.md
@@ -15,28 +15,28 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-clamav-client = "1.0.1"
+clamav-client = "2.0.0"
 ```
 
 To use the `async` functions in `clamav_client::tokio`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-clamav-client = { version = "1.0.1", features = ["tokio"] }
+clamav-client = { version = "2.0.0", features = ["tokio"] }
 ```
 
 To scan Tokio streams, enable the `tokio-stream` feature instead and add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-clamav-client = { version = "1.0.1", features = ["tokio-stream"] }
+clamav-client = { version = "2.0.0", features = ["tokio-stream"] }
 ```
 
 Support for `async-std` is also available by enabling the `async-std` feature:
 
 ```toml
 [dependencies]
-clamav-client = { version = "1.0.1", features = ["async-std"] }
+clamav-client = { version = "2.0.0", features = ["async-std"] }
 ```
 
 ## Migrations

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -5,7 +5,6 @@ use async_std::{
     path::Path,
     stream::{Stream, StreamExt},
 };
-use async_trait::async_trait;
 
 #[cfg(unix)]
 use async_std::os::unix::net::UnixStream;
@@ -109,31 +108,28 @@ pub struct Socket<P: AsRef<Path>> {
 }
 
 /// The communication protocol to use
-#[async_trait(?Send)]
 pub trait TransportProtocol {
     /// Bidirectional stream
     type Stream: ReadExt + WriteExt + Unpin;
 
     /// Converts the protocol instance into the corresponding stream
-    async fn connect(&self) -> io::Result<Self::Stream>;
+    fn connect(&self) -> impl std::future::Future<Output = io::Result<Self::Stream>>;
 }
 
-#[async_trait(?Send)]
 impl<A: ToSocketAddrs> TransportProtocol for Tcp<A> {
     type Stream = TcpStream;
 
-    async fn connect(&self) -> io::Result<Self::Stream> {
-        TcpStream::connect(&self.host_address).await
+    fn connect(&self) -> impl std::future::Future<Output = io::Result<Self::Stream>> {
+        TcpStream::connect(&self.host_address)
     }
 }
 
-#[async_trait(?Send)]
 #[cfg(unix)]
 impl<P: AsRef<Path>> TransportProtocol for Socket<P> {
     type Stream = UnixStream;
 
-    async fn connect(&self) -> io::Result<Self::Stream> {
-        UnixStream::connect(&self.socket_path).await
+    fn connect(&self) -> impl std::future::Future<Output = io::Result<Self::Stream>> {
+        UnixStream::connect(&self.socket_path)
     }
 }
 


### PR DESCRIPTION
Inspired by #13 and feedback from @raui100, this PR restores the `Send` and `Sync` traits after they had been explicitly removed because of a problem with `async-trait`.