### PR TITLE
feat: Add TransportProtocol for &T

### DIFF
--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -136,6 +136,17 @@ impl<P: AsRef<Path>> TransportProtocol for Socket<P> {
     }
 }
 
+impl<T> TransportProtocol for &T
+where
+    T: TransportProtocol,
+{
+    type Stream = T::Stream;
+
+    fn connect(&self) -> impl std::future::Future<Output = io::Result<Self::Stream>> {
+        TransportProtocol::connect(*self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,17 @@ impl<P: AsRef<Path>> TransportProtocol for Socket<P> {
     }
 }
 
+impl<T> TransportProtocol for &T
+where
+    T: TransportProtocol,
+{
+    type Stream = T::Stream;
+
+    fn connect(&self) -> io::Result<Self::Stream> {
+        TransportProtocol::connect(*self)
+    }
+}
+
 /// Sends a ping request to ClamAV
 ///
 /// This function establishes a connection to a ClamAV server and sends the PING

--- a/src/smol.rs
+++ b/src/smol.rs
@@ -136,6 +136,17 @@ impl<P: AsRef<Path>> TransportProtocol for Socket<P> {
     }
 }
 
+impl<T> TransportProtocol for &T
+where
+    T: TransportProtocol,
+{
+    type Stream = T::Stream;
+
+    fn connect(&self) -> impl std::future::Future<Output = io::Result<Self::Stream>> {
+        TransportProtocol::connect(*self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -139,6 +139,17 @@ impl<P: AsRef<Path>> TransportProtocol for Socket<P> {
     }
 }
 
+impl<T> TransportProtocol for &T
+where
+    T: TransportProtocol,
+{
+    type Stream = T::Stream;
+
+    fn connect(&self) -> impl std::future::Future<Output = io::Result<Self::Stream>> {
+        TransportProtocol::connect(*self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
@toblux hello! Thank you for the library! 

My use case is I want to share `transport` between call: 

```rust
struct Agent {
    transport: Socket<PathBuf>
}

impl Agent {
    fn scan_file(&self) {
        let _ = clamav_client::scan_file(&self.transport)
    }
}
```